### PR TITLE
necessary since we cannot have keywordsInput in the dependency array

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Deploy Project to App Engine
-# env: 
-#   CI: false
+env: 
+  CI: false
 
 on:
   push:


### PR DESCRIPTION
having keywordsInput and submitPrompt in the dependency array leads to re-render which pauses the timer (because it comes from the text area value which updates everytime a user types something). therefore we need to disable this warning. else look for a new complicated approach which is not clear at the moment